### PR TITLE
MNT: fix Azure CI infrastructure failures blocking maintainer-removal PRs

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-11
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,7 @@
-cdt_name:
-- cos6
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,10 +9,10 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libjpeg_turbo:
-- 2.1.5
+- '3'
 target_platform:
 - linux-64

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,5 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,9 +13,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '19'
 libjpeg_turbo:
-- 2.1.5
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -11,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -23,10 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --quiet --yes --channel conda-forge \
+    python=3.12 conda-build pip boa conda-forge-ci-setup=4
+mamba update --yes --quiet --channel conda-forge \
+    python=3.12 conda-build pip boa conda-forge-ci-setup=4
 
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-# Downgrade the C++ standard because `throw` is no longer supported.
-# We do this (instead of downgrading the compiler) to avoid any ABI compatibility issues.
+# Force C++14 because this codebase uses dynamic exception specifications
+# (throw(...)) that are rejected under modern compiler defaults (C++17+).
+# We do this (instead of downgrading the compiler) to avoid ABI compatibility issues.
 # See:
 # - https://github.com/conda/conda-build/issues/3097
 # - https://stackoverflow.com/a/49119902/2427624
-if [[ ${target_platform} =~ .*linux.* ]]; then
-    CXXFLAGS="${CXXFLAGS//++17/++14 -fpermissive}"
-fi
+CXXFLAGS="${CXXFLAGS} -std=gnu++14 -fpermissive"
 
 ./configure --prefix=${PREFIX} --with-ltl=${PREFIX} --with-libjpeg=${PREFIX}
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,19 +3,20 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
   url: http://www.usm.uni-muenchen.de/people/cag/{{ name }}-{{ version }}.tar.gz
   sha256: 091c22dcb2445141727fe26f06a7d4ac767bd3a839d92fb277df31dbf976761e
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
     - autoconf
     - automake


### PR DESCRIPTION
This PR applies targeted fixes to unblock maintainer-removal PRs (including #12) that are currently blocked by infrastructure/lint failures.

Changes:
- update Azure macOS runner image from macOS-11 to macOS-15
- update conda-forge-ci-setup pin from 3 to 4 in Linux and OSX build scripts
- update the OSX bootstrap installer artifact name from Mambaforge to Miniforge3
- fix OSX solver conflict by pinning python=3.12 in mamba install/update commands
- resolve conda-forge-linter findings in recipe/meta.yaml:
  - quote package.version
  - add {{ stdlib("c") }} to build requirements when using compiler
  - bump build number from 2 to 3

Supersedes #13 to follow fork-based feedstock workflow.

Co-Authored-By: Oz <oz-agent@warp.dev>