### PR TITLE
MNT: rerender README maintainer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/fitstools-feeds
 
 Home: https://www.usm.uni-muenchen.de/people/cag/fitstools.html
 
-Package license: GPL-2.0
+Package license: GPL-2.0-only
 
 Summary: Basic shell commandline programs that can perform many operations on FITS files
 
@@ -121,15 +121,15 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -156,7 +156,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/fitstools-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
@@ -170,5 +170,4 @@ Feedstock Maintainers
 =====================
 
 * [@drbixx](https://github.com/drbixx/)
-* [@teake](https://github.com/teake/)
 


### PR DESCRIPTION
Rerendered feedstock output to update the generated README maintainer section from current metadata.

Result:
- removes @teake from the README feedstock maintainer list

This keeps the update aligned with feedstock-generated content rather than manually editing generated output.

Co-Authored-By: Oz <oz-agent@warp.dev>